### PR TITLE
fix: fix gif imports throwing errors

### DIFF
--- a/client/src/classes/effects/ProjectileExplosionEffect.ts
+++ b/client/src/classes/effects/ProjectileExplosionEffect.ts
@@ -1,24 +1,28 @@
 import { Vector2DTO } from '@shared/dtos/Vector2DTO'
-import { Assets, Container } from 'pixi.js'
+import { Container } from 'pixi.js'
 import ExplosionImage from '@assets/spr_explosion.gif'
 import { AnimatedGIF } from '@pixi/gif'
 
 export class ProjectileExplosionEffect {
     sprite: AnimatedGIF | undefined = undefined
+
     constructor(stage: Container, position: Vector2DTO) {
-        Assets.load(ExplosionImage).then((loadedGif: AnimatedGIF) => {
-            loadedGif.texture.source.scaleMode = 'nearest'
-            loadedGif.loop = false
-            this.sprite = loadedGif.clone()
-            this.sprite.anchor.set(0.5, 0.5)
-            this.sprite.position.set(position.x, position.y)
-            this.sprite.animationSpeed = 2
-            this.sprite.angle = Math.random() * 360
-            this.sprite.zIndex = position.y + 100
-            this.sprite.onComplete = () => {
-                stage.removeChild(this.sprite as Container)
-            }
-            stage.addChild(this.sprite)
-        })
+        fetch(ExplosionImage)
+            .then((res) => res.arrayBuffer())
+            .then(AnimatedGIF.fromBuffer)
+            .then((loadedGif) => {
+                loadedGif.loop = false
+                loadedGif.texture.source.scaleMode = 'nearest'
+                this.sprite = loadedGif.clone()
+                this.sprite.anchor.set(0.5, 0.5)
+                this.sprite.position.set(position.x, position.y)
+                this.sprite.animationSpeed = 2
+                this.sprite.angle = Math.random() * 360
+                this.sprite.zIndex = position.y + 100
+                this.sprite.onComplete = () => {
+                    stage.removeChild(this.sprite as Container)
+                }
+                stage.addChild(this.sprite)
+            })
     }
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,7 +3,6 @@ import App from './App.tsx'
 import { Application, Renderer } from 'pixi.js'
 import { SetupHelper } from './classes/SetupHelper.ts'
 import '@pixi/gif'
-import 'pixi.js'
 
 const CANVAS_WIDTH = 640
 const CANVAS_HEIGHT = 380


### PR DESCRIPTION
Assets load does not seem to work as expected using @pixi/gif so I used fetch instead